### PR TITLE
feat: init gif table

### DIFF
--- a/front/src/components/TeamCard.vue
+++ b/front/src/components/TeamCard.vue
@@ -34,7 +34,8 @@
         >Leave</button>
       </div>
       <div class="card-footer-item">
-        <button class="button is-info">See GIFs</button>
+<!--        <button class="button is-info" >See GIFs</button>-->
+        <router-link class="button is-info" :to="{ name: 'gifs', params: { teamId: team.uid}}">See GIFs</router-link>
       </div>
     </footer>
   </div>

--- a/front/src/components/TeamCard.vue
+++ b/front/src/components/TeamCard.vue
@@ -34,7 +34,6 @@
         >Leave</button>
       </div>
       <div class="card-footer-item">
-<!--        <button class="button is-info" >See GIFs</button>-->
         <router-link class="button is-info" :to="{ name: 'gifs', params: { teamId: team.uid}}">See GIFs</router-link>
       </div>
     </footer>

--- a/front/src/router/index.js
+++ b/front/src/router/index.js
@@ -18,6 +18,15 @@ const routes = [
     // which is lazy-loaded when the route is visited.
     component: () =>
       import(/* webpackChunkName: "about" */ '../views/Teams.vue')
+  },
+  {
+    path: '/gifs',
+    name: 'gifs',
+    // route level code-splitting
+    // this generates a separate chunk (about.[hash].js) for this route
+    // which is lazy-loaded when the route is visited.
+    component: () =>
+      import(/* webpackChunkName: "about" */ '../views/Gifs.vue')
   }
 ];
 

--- a/front/src/views/Gifs.vue
+++ b/front/src/views/Gifs.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="gifs">
+    <h2>GIFFFFFSSSS</h2>
+    <div class="table-container">
+      <table class="table is-bordered is-striped is-narrow is-hoverable">
+        <thead>
+          <tr>
+            <th>Day</th>
+            <th>Theme</th>
+            <th>Preview</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th>Monday</th>
+            <td>Monday Theme</td>
+            <td>Preview</td>
+          </tr>
+          <tr>
+            <th>Tuesday</th>
+            <td>Tuesday Theme</td>
+            <td>Preview</td>
+          </tr>
+          <tr>
+            <th>Wednesday</th>
+            <td>Wednesday Theme</td>
+            <td>Preview</td>
+          </tr>
+          <tr>
+            <th>Thursday</th>
+            <td>Thursday Theme</td>
+            <td>Preview</td>
+          </tr>
+          <tr>
+            <th>Friday</th>
+            <td>Friday Theme</td>
+            <td>Preview</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<script>
+// @ is an alias to /src
+// import HelloWorld from '@/components/HelloWorld.vue'
+
+export default {
+  name: 'gifs',
+  components: {
+  }
+}
+</script>


### PR DESCRIPTION
![GitHub issue/pull request detail](https://img.shields.io/github/issues/detail/title/ytvnr/gif-of-the-day/10?color=red&style=for-the-badge&logo=vue.js)

## Description

Init gif table with fake data.
This page is accessible by clicking on See Gifs button from Teams view.

## Screenshot
![image](https://user-images.githubusercontent.com/47851994/72257213-5b265380-360b-11ea-9431-e320d37cbdff.png)

## GIF !
![](https://media3.giphy.com/media/ALDLclNlAmFfa/giphy.gif?cid=5a38a5a22447f21afdd6dcb96d8f342cd89e8891613b79c8&rid=giphy.gif)