### PR TITLE
feat: use store for assignedTeamId

### DIFF
--- a/front/src/components/TeamCard.vue
+++ b/front/src/components/TeamCard.vue
@@ -21,8 +21,8 @@
     </v-list-item>
 
     <v-card-actions>
-      <v-btn class="ma-2" outlined color="green" text @click="joinTeam()" :disabled="userMetadata.assignedTeamId === team.id">Join team</v-btn>
-      <v-btn class="ma-2" outlined color="red darken-1" text @click="leaveTeam()" :disabled="userMetadata.assignedTeamId !== team.id">Leave team</v-btn>
+      <v-btn class="ma-2" outlined color="green" text @click="joinTeam()" :disabled="this.assignedTeamId === team.id">Join team</v-btn>
+      <v-btn class="ma-2" outlined color="red darken-1" text @click="leaveTeam()" :disabled="this.assignedTeamId !== team.id">Leave team</v-btn>
       <router-link :to="{ name: 'gifs', params: { teamId: team.id}}">
         <v-btn class="ma-2" outlined color="lime">See GIFs</v-btn>
       </router-link>
@@ -47,6 +47,9 @@ export default {
     computed: {
       user() {
         return this.$store.getters.user;
+      },
+      assignedTeamId() {
+        return this.$store.getters.assignedTeamId;
       }
     },
     mounted() {
@@ -55,21 +58,22 @@ export default {
       .get()
       .then(snapshot => {
         this.userMetadata = snapshot.data();
-      })
+        this.$store.dispatch('assignTeamAction', this.userMetadata.assignedTeamId);
+      });
+
     },
     methods: {
-      joinTeam() {  
+      joinTeam() {
         db.collection("usersMetadata").doc(this.user.uid).set({
           assignedTeamId: this.team.id
         }, { merge: true });
-        // temprorary fix to disable join button
-        // TODO: handle team selection ion Team.vue to sync all buttons
-        this.userMetadata.assignedTeamId = this.team.id;
+        this.$store.dispatch('assignTeamAction', this.team.id);
       },
       leaveTeam() {
         this.userMetadata = db.collection("usersMetadata").doc(this.user.uid).update({
           assignedTeamId: firebase.firestore.FieldValue.delete()
         });
+        this.$store.dispatch('assignTeamAction', null);
       }
     },
 }

--- a/front/src/store/index.js
+++ b/front/src/store/index.js
@@ -8,7 +8,8 @@ export default new Vuex.Store({
   state: {
     user: null,
     status: null,
-    error: null
+    error: null,
+    assignedTeamId: null
   },
   mutations: {
     setUser(state, payload) {
@@ -25,13 +26,15 @@ export default new Vuex.Store({
 
     setError(state, payload) {
       state.error = payload;
+    },
+
+    setAssignedTeamId(state, payload) {
+      state.assignedTeamId = payload;
     }
   },
   actions: {
-    assignTeamAction({ dispatch }, teamId) {
-      dispatch('updateUserAction', {
-        assignedTeam: teamId
-      });
+    assignTeamAction({ commit }, teamId) {
+      commit('setAssignedTeamId', teamId);
     },
 
     autoLoginAction({commit}, user) {
@@ -50,6 +53,7 @@ export default new Vuex.Store({
           commit('setUser', user);
           commit('setStatus', 'success');
           commit('setError', null);
+          commit('setAssignedTeamId', user.assignedTeamId);
         })
         .catch(error => {
           commit('setStatus', 'failure');
@@ -68,6 +72,7 @@ export default new Vuex.Store({
           commit('setUser', response.user);
           commit('setStatus', 'success');
           commit('setError', null);
+          commit('setAssignedTeamId', response.user.assignedTeamId);
         })
         .catch(error => {
           commit('setStatus', 'failure');
@@ -83,6 +88,7 @@ export default new Vuex.Store({
           commit('setUser', null);
           commit('setStatus', 'success');
           commit('setError', null);
+          commit('setAssignedTeamId', null);
         })
         .catch(error => {
           commit('setStatus', 'failure');
@@ -102,6 +108,10 @@ export default new Vuex.Store({
 
     error(state) {
       return state.error;
+    },
+
+    assignedTeamId(state) {
+      return state.assignedTeamId;
     }
   }
 });


### PR DESCRIPTION
![GitHub issue/pull request detail](https://img.shields.io/github/issues/detail/title/ytvnr/gif-of-the-day/28?color=red&style=for-the-badge&logo=vue.js) #28 
![GitHub issue/pull request detail](https://img.shields.io/github/issues/detail/title/ytvnr/gif-of-the-day/51?color=red&style=for-the-badge&logo=vue.js) #51 

## Description

Use store to manage assignedTeamId and make the "Join page" in real time and good state

## Screenshot

![Enregistrement de l’écran 2020-02-13 à 21 04 03](https://user-images.githubusercontent.com/47851994/74474273-781da300-4ea5-11ea-8075-7a8bc244cc6a.gif)

## GIF !

![](https://media1.giphy.com/media/4Zo41lhzKt6iZ8xff9/giphy.gif?cid=5a38a5a2fc864852d7f74623518fee44c49b261223453536&rid=giphy.gif)
