### PR TITLE
feat: display home page content

### DIFF
--- a/front/src/store/index.js
+++ b/front/src/store/index.js
@@ -121,7 +121,25 @@ export default new Vuex.Store({
       firebase
         .auth()
         .signInWithEmailAndPassword(user.email, user.password)
+        .then(response => {
+          commit('setUser', response.user);
+          commit('setStatus', 'success');
+          commit('setError', null);
+
+          // TODO: dupplicated code in signInWithGoogleAction. To refactor
+          firebase
+            .firestore()
+            .collection('usersMetadata')
+            .doc(response.user.uid)
+            .get()
+            .then(snapshot => {
+              this.userMetadata = snapshot.data();
+              commit('setAssignedTeamId', this.userMetadata.assignedTeamId);
+            });
+        })
         .catch(function(error) {
+          commit('setStatus', 'failure');
+          commit('setError', error.message);
           console.error(error);
         })
     },
@@ -145,7 +163,7 @@ export default new Vuex.Store({
             .get()
             .then(snapshot => {
               this.userMetadata = snapshot.data();
-              commit('setAssignedTeamId', this.userMetadata.assignedTeamId);
+              commit('setAssignedTeamId', this.userMetadata?.assignedTeamId);
             });
         })
         .catch(error => {

--- a/front/src/views/Home.vue
+++ b/front/src/views/Home.vue
@@ -1,16 +1,52 @@
 <template>
   <div class="home">
-    #home
+    <div v-if="assignedTeamId" class="content">
+      <h1>The gif of the day is <b class="todo">to be defined</b> for team</h1>
+      {{assignedTeamId}}
+    </div>
+
+    <div v-if="!assignedTeamId" class="content">
+      <h1>Your are not assigned to a team. Please join one:</h1>
+
+      <router-link :to="{ name: 'teams'}">
+        <v-btn class="ma-2" outlined color="lime">Join a team!</v-btn>
+      </router-link>
+    </div>
   </div>
 </template>
 
 <script>
-// @ is an alias to /src
-// import HelloWorld from '@/components/HelloWorld.vue'
 
 export default {
   name: 'home',
   components: {
+  },
+  computed: {
+    assignedTeamId() {
+      return this.$store.getters.assignedTeamId;
+    }
   }
 }
 </script>
+
+<style>
+  .home {
+    height: 90vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .content {
+    text-align: center;
+  }
+
+  a {
+    text-decoration: none;
+  }
+
+  .todo {
+    color: orange;
+  }
+</style>

--- a/front/src/views/Logout.vue
+++ b/front/src/views/Logout.vue
@@ -6,6 +6,8 @@
 export default {
     beforeCreate() {
       this.$store.dispatch('signOutAction');
+
+      this.$router.push('/login');
     },
     computed: {
       user() {


### PR DESCRIPTION
## Description

- Propose to join a team on Home page when none assigned
- Display the gif of the day (not available for now) for assigned team (id displayed for now)
- BONUS: Display Login page when Logout

## Screenshot
![Capture d’écran 2020-03-19 à 07 54 18](https://user-images.githubusercontent.com/47851994/77039919-39ed3500-69b7-11ea-9842-86f17b946571.png)
![Capture d’écran 2020-03-19 à 07 54 27](https://user-images.githubusercontent.com/47851994/77039921-3b1e6200-69b7-11ea-9722-838e42640653.png)


## GIF !

![](https://media3.giphy.com/media/h4BLlvyUM2CVFK683U/giphy.gif?cid=5a38a5a2105eb222b85de835089b7b874560d10449196d8e&rid=giphy.gif)
