### PR TITLE
feat: edit theme for a day, save it and display it in home page 💄💪

### DIFF
--- a/front/src/services/teams.service.js
+++ b/front/src/services/teams.service.js
@@ -1,0 +1,49 @@
+import firebase from 'firebase';
+
+const db = firebase.firestore();
+
+export default class TeamsService {
+
+    getTheme(teamId, date) {
+
+        let start = new Date();
+        start.setDate(date);
+        start.setUTCHours(0,0,0,0);
+        let end = new Date();
+        end.setDate(date);
+        end.setUTCHours(23,59,59,0);
+
+        return db.collection('themes')
+            .where('team', '==', db.collection('teams').doc(teamId))
+            .where('date', '>=', start)
+            .where('date', '<=', end)
+            .get();
+    }
+
+    getThemesBetweenDates(teamId, start, end) {
+        return db.collection('themes')
+            .where('team', '==', db.collection('teams').doc(teamId))
+            .where('date', '>=', start)
+            .where('date', '<=', end)
+            .get();
+    }
+
+    saveTheme(id, theme, teamId, date) {
+
+        if (id) {
+            return db.collection('themes')
+                .doc(id)
+                .set({
+                    theme,
+                }, { merge: true });
+
+        } else {
+            return db.collection('themes')
+                .add({
+                    theme,
+                    team: db.collection('teams').doc(teamId),
+                    date
+                });
+        }
+    }
+}

--- a/front/src/views/Home.vue
+++ b/front/src/views/Home.vue
@@ -42,10 +42,15 @@
                             >The Gif of the Day</v-card-title
                         >
 
-                        <v-card-subtitle
+                        <v-card-subtitle v-if="todayTheme && theme"
                             >The theme for today is:
-                            <strong>Frenchie</strong></v-card-subtitle
+                            <strong>{{theme}}</strong></v-card-subtitle
                         >
+                        <v-card-actions v-if="!(todayTheme && theme)">
+                            <router-link :to="{ name: 'schedule' }">
+                                <v-btn text>Choose a theme!</v-btn>
+                            </router-link>
+                        </v-card-actions>
                     </v-card>
                 </v-col>
             </v-row>
@@ -67,7 +72,6 @@
 import firebase from 'firebase';
 
 //TODO: ideally, we should use the TeamsService here, but firebase.initializeApp is not finished then we have no access to db
-
 
 export default {
     name: 'home',
@@ -124,11 +128,9 @@ export default {
         },
         todayTheme() {
             const id = this.$store.getters.assignedTeamId;
-            console.log('theme')
             if(id) {
                 this.getTheme(id);
             }
-            console.log('theme', id)
             return id;
         },
     },

--- a/front/src/views/Home.vue
+++ b/front/src/views/Home.vue
@@ -66,11 +66,15 @@
 <script>
 import firebase from 'firebase';
 
+//TODO: ideally, we should use the TeamsService here, but firebase.initializeApp is not finished then we have no access to db
+
+
 export default {
     name: 'home',
     data() {
         return {
             team: null,
+            theme: null
         };
     },
     methods: {
@@ -83,6 +87,29 @@ export default {
                     this.team = snapshot.data();
                 });
         },
+        getTheme(teamId) {
+
+            const db = firebase.firestore();
+            let start = new Date();
+            start.setUTCHours(0,0,0,0);
+            let end = new Date();
+            end.setUTCHours(23,59,59,0);
+
+            db.collection('themes')
+                .where('team', '==', db.collection('teams').doc(teamId))
+                .where('date', '>=', start)
+                .where('date', '<=', end)
+                .get()
+                .then(snapshots => {
+                    if (snapshots.size !== 1) {
+                        throw new Error('Cannot have multiple result');
+                    }
+                    snapshots.forEach((doc) => {
+                        const item = doc.data();
+                        this.theme = item.theme;
+                    });
+                });
+        }
     },
     computed: {
         user() {
@@ -93,6 +120,15 @@ export default {
             if (id) {
                 this.getTeamById(id);
             }
+            return id;
+        },
+        todayTheme() {
+            const id = this.$store.getters.assignedTeamId;
+            console.log('theme')
+            if(id) {
+                this.getTheme(id);
+            }
+            console.log('theme', id)
             return id;
         },
     },


### PR DESCRIPTION
## Description

- [x] Be able to choose a theme or edit it in Schedule page
- [x] Display the theme in Home page
- [x] If no theme for today, home page links to schedule to choose one

⚠️⚠️
- TeamsService has been created. It does not works on Home page. As the first page to be displayed, firebase.initializeApp() is not finished, and then we cannot use the db. 
We will have to find a way to have this properly.
- If a theme is manually added in db, the date is 12:00 AM UTC+1, which is not retrieved by the request from app -> there may be an issue with the param for the request
⚠️⚠️

## Screenshot
![Capture d’écran 2020-03-26 à 07 46 54](https://user-images.githubusercontent.com/47851994/77618640-ffdfde00-6f36-11ea-8d60-80b8756ab064.png)
![Capture d’écran 2020-03-26 à 07 47 16](https://user-images.githubusercontent.com/47851994/77618654-02dace80-6f37-11ea-9c72-a0ee53a60fab.png)
![Capture d’écran 2020-03-26 à 07 47 40](https://user-images.githubusercontent.com/47851994/77618657-02dace80-6f37-11ea-9938-7c70c34c1ba8.png)
![Capture d’écran 2020-03-26 à 07 47 50](https://user-images.githubusercontent.com/47851994/77618659-03736500-6f37-11ea-98f7-a51120bb56ba.png)

## GIF !

![](https://media2.giphy.com/media/Cie9cWGeqVYHe/giphy.gif?cid=5a38a5a24041516899c22cc15c0654d9e23ca65a76b34807&rid=giphy.gif)
