### PR TITLE
fix: display team name if we have team 🐛

### DIFF
--- a/front/src/views/Home.vue
+++ b/front/src/views/Home.vue
@@ -19,7 +19,7 @@
                     <v-card color="amber darken-3" dark>
                         <v-card-title class="headline">Your team</v-card-title>
 
-                        <v-card-subtitle v-if="assignedTeam"
+                        <v-card-subtitle v-if="team"
                             >Your team is {{ team.name }}</v-card-subtitle
                         >
 


### PR DESCRIPTION
## Description

I replace if condition with assignTeamId by team 👍 

![image](https://user-images.githubusercontent.com/3717296/77647528-dccd2280-6f66-11ea-92f1-288e41d7c17b.png)

## GIF !

![](https://media0.giphy.com/media/1xOQlQxrIX4Jw6lBZI/giphy.gif?cid=5a38a5a2f1fbae42e88a647525057f94434a2c77b05cfcab&rid=giphy.gif)
