### PR TITLE
fix: call assignedTeamId computed to init it

### DIFF
--- a/front/src/views/Home.vue
+++ b/front/src/views/Home.vue
@@ -9,7 +9,7 @@
                             {{ user.displayName || user.email }}
                         </v-card-title>
 
-                        <v-card-subtitle v-if="storedAssignedTeamId">Random phrase of the day !</v-card-subtitle>
+                        <v-card-subtitle v-if="assignedTeamId && storedAssignedTeamId">Random phrase of the day !</v-card-subtitle>
                     </v-card>
                 </v-col>
 


### PR DESCRIPTION
## Description

Home page was unable to display teams and gif info anymore because `computed` method `assignedTeamId` was not called 
I just add one call in the template

## GIF !


![](https://media3.giphy.com/media/14jYF26BS8EOac/giphy.gif?cid=5a38a5a2292af96111a8cb580cb9edbe77edaeb9835129ce&rid=giphy.gif)
