### PR TITLE
fix: register with display name

### DIFF
--- a/front/src/services/teams.service.js
+++ b/front/src/services/teams.service.js
@@ -14,16 +14,19 @@ export default class TeamsService {
 
     getTheme(teamId) {
 
-        let start = new Date();
-        start.setUTCHours(0,0,0,0);
-        let end = new Date();
-        end.setUTCHours(23,59,59,0);
+        if (teamId) {
+            let start = new Date();
+            start.setUTCHours(0,0,0,0);
+            let end = new Date();
+            end.setUTCHours(23,59,59,0);
 
-        return this.db.collection('themes')
-            .where('team', '==', this.db.collection('teams').doc(teamId))
-            .where('date', '>=', start)
-            .where('date', '<=', end)
-            .get();
+            return this.db.collection('themes')
+                .where('team', '==', this.db.collection('teams').doc(teamId))
+                .where('date', '>=', start)
+                .where('date', '<=', end)
+                .get();
+        }
+        return Promise.resolve([]);
     }
 
     getThemesBetweenDates(teamId, start, end) {

--- a/front/src/store/index.js
+++ b/front/src/store/index.js
@@ -123,9 +123,19 @@ export default new Vuex.Store({
                                 user.email,
                                 user.password
                             )
-                            .then(() => {
-                                commit('setStatus', 'success');
-                                commit('setError', null);
+                            .then(registered => {
+                                registered.user.updateProfile({
+                                    displayName: `${user.firstName} ${user.lastName}`
+                                })
+                                .then(() => {
+                                    commit('setStatus', 'success');
+                                    commit('setError', null);
+                                })
+                                .catch(error => {
+                                    commit('setStatus', 'failure');
+                                    commit('setError', error.message);
+                                });
+
                             })
                             .catch(function(error) {
                                 commit('setStatus', 'failure');

--- a/front/src/views/Register.vue
+++ b/front/src/views/Register.vue
@@ -18,6 +18,24 @@
                         class="error"
                         v-if="!$v.repeatPassword.sameAsPassword"
                     >Passwords must be identical.</div>
+                    <div
+                            class="error"
+                            v-if="!$v.firstName.required"
+                    >First name is required.</div>
+
+                    <div
+                            class="error"
+                            v-if="!$v.firstName.maxLength"
+                    >First name max length is {{ $v.firstName.$params.maxLength.max }} letters.</div>
+                    <div
+                            class="error"
+                            v-if="!$v.lastName.required"
+                    >Last name is required.</div>
+
+                    <div
+                            class="error"
+                            v-if="!$v.lastName.maxLength"
+                    >Last name max length is {{ $v.lastName.$params.maxLength.max }} letters.</div>
                 </v-sheet>
 
                 <v-card-text>
@@ -50,6 +68,26 @@
                             type="password"
                             v-model="$v.repeatPassword.$model"
                         />
+
+                        <v-text-field
+                                required
+                                id="firstName"
+                                label="First Name"
+                                name="firstName"
+                                prepend-icon="mdi-emoticon"
+                                type="text"
+                                v-model="$v.firstName.$model"
+                        />
+
+                        <v-text-field
+                                required
+                                id="lastName"
+                                label="Last Name"
+                                name="lastName"
+                                prepend-icon="mdi-emoticon-cool"
+                                type="text"
+                                v-model="$v.lastName.$model"
+                        />
                     </v-form>
                 </v-card-text>
                 <v-card-actions class="text-center">
@@ -76,7 +114,7 @@
 </template>
 
 <script>
-import { required, email, minLength, sameAs } from 'vuelidate/lib/validators'
+import { required, email, minLength, maxLength, sameAs } from 'vuelidate/lib/validators'
 
 export default {
     data() {
@@ -84,6 +122,8 @@ export default {
             email: "",
             password: "",
             repeatPassword: "",
+            lastName: "",
+            firstName: ""
         }
     },
     validations: {
@@ -99,6 +139,14 @@ export default {
             required,
             sameAsPassword: sameAs('password'), 
             minLength: minLength(5),
+        },
+        lastName: {
+            required,
+            maxLength: maxLength(30),
+        },
+        firstName: {
+            required,
+            maxLength: maxLength(30),
         }
     },
     methods: {
@@ -107,7 +155,9 @@ export default {
                 this.$store.dispatch('createUserWithEmailAndPassword', {
                     email: this.email,
                     password: this.password,
-                    password2: this.password2
+                    password2: this.password2,
+                    lastName: this.lastName,
+                    firstName: this.firstName
                 });
             }
         }


### PR DESCRIPTION
![GitHub issue/pull request detail](https://img.shields.io/github/issues/detail/title/ytvnr/gif-of-the-day/92?color=red&style=for-the-badge&logo=vue.js)
Fixes #92 

## Description
Register with first name and last name to display a friendly name in home page

## Screenshot
![Capture d’écran 2020-04-01 à 07 03 48](https://user-images.githubusercontent.com/47851994/78103373-19789e00-73ed-11ea-9fbc-6b89d379f8d0.png)
![Capture d’écran 2020-04-01 à 07 03 54](https://user-images.githubusercontent.com/47851994/78103374-1a113480-73ed-11ea-9a85-1cbdbdd3a767.png)
![Capture d’écran 2020-04-01 à 07 03 57](https://user-images.githubusercontent.com/47851994/78103377-1b426180-73ed-11ea-8fda-131b1a5e2f61.png)
![Capture d’écran 2020-04-01 à 07 47 37](https://user-images.githubusercontent.com/47851994/78103378-1bdaf800-73ed-11ea-8979-11a6e8bd35e7.png)

## GIF !

![](https://media2.giphy.com/media/ko1n9SyUdZwNW/giphy.gif?cid=5a38a5a2ccdbeaf8a19036caad7925cf9436d6b43850b495&rid=giphy.gif)
