### PR TITLE
feat: redesign team card

### DIFF
--- a/front/src/components/TeamCard.vue
+++ b/front/src/components/TeamCard.vue
@@ -1,10 +1,13 @@
 <template>
-    <v-card class="mx-auto" max-width="75%" outlined>
+    <v-card
+            class="mx-auto"
+            :class="{ 'selected': this.assignedTeamId === team.id }"
+            max-width="85%"
+            outlined >
         <v-list-item three-line>
             <v-list-item-content>
                 <div class="overline mb-4">Teams</div>
                 <v-list-item-title class="headline mb-1">{{team.name}}</v-list-item-title>
-                <v-list-item-subtitle>Awesome Subtitle</v-list-item-subtitle>
             </v-list-item-content>
 
             <v-list-item-avatar tile size="80" color="grey">
@@ -14,24 +17,21 @@
 
         <v-card-actions>
             <v-btn
+                v-if="this.assignedTeamId !== team.id"
                 class="ma-2"
                 outlined
                 color="green"
                 text
                 @click="joinTeam()"
-                :disabled="this.assignedTeamId === team.id"
             >Join team</v-btn>
             <v-btn
+                v-if="this.assignedTeamId === team.id"
                 class="ma-2"
                 outlined
                 color="red darken-1"
                 text
                 @click="leaveTeam()"
-                :disabled="this.assignedTeamId !== team.id"
             >Leave team</v-btn>
-            <router-link :to="{ name: 'gifs', params: { teamId: team.id}}">
-                <v-btn class="ma-2" outlined color="lime">See GIFs</v-btn>
-            </router-link>
         </v-card-actions>
     </v-card>
 </template>
@@ -66,6 +66,10 @@ export default {
 </script>
 
 <style>
+.selected {
+    background-color: rgba(30, 30, 30, 0.12) !important;
+    box-shadow: 0 0 30px 5px lime;
+}
 a {
     text-decoration: none;
 }


### PR DESCRIPTION
![GitHub issue/pull request detail](https://img.shields.io/github/issues/detail/title/ytvnr/gif-of-the-day/62?color=red&style=for-the-badge&logo=vue.js)
Fixes #62

## Description

Change the design of team card. 
- Keep only one button in card to join or leave
- Show explicitly the selected team

## Screenshot

![Uploading image.png…]()

## GIF !

![](https://media3.giphy.com/media/eSQKNSmg07dHq/giphy.gif?cid=5a38a5a297c7c2690db45168a61610e26eff4b3eddb304e4&rid=giphy.gif)
