### PR TITLE
feat: no teams text

### DIFF
--- a/front/src/views/Teams.vue
+++ b/front/src/views/Teams.vue
@@ -9,13 +9,16 @@
             <div class="list" v-if="!user">
                 <h2 class="subtitle has-text-danger">You do not have access to this page !</h2>
             </div>
-            <div class="list" v-if="user">
+            <div class="list" v-if="user && teams.length > 0">
                 <god-cardteam
                     class="item"
                     v-for="(team, index) in teams"
                     :key="`team-${index}`"
                     :team="team"
                 ></god-cardteam>
+            </div>
+            <div v-if="user && teams.length === 0">
+                <p>⚠️ There is no team for this organization 😭</p>
             </div>
         </div>
     </section>


### PR DESCRIPTION
## Description

Give an information when there is no team affected to an organization

## Screenshot

![Capture d’écran 2020-04-10 à 13 42 51](https://user-images.githubusercontent.com/47851994/78988524-6f59ee00-7b31-11ea-87b3-bbcdfde1a5df.png)

## GIF !


![](https://media2.giphy.com/media/UyWXNumwNvXmE/giphy.gif?cid=5a38a5a2aece9ad9a0e7be49ba3d491504b0f0756c7b7bf2&rid=giphy.gif)

