### PR TITLE
feat: display the chooser of a theme and fix date issue

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,7 @@ Each document is structured like this:
 | date | timestamp | March, 30 2020 11:11:11AM | Use `Date` object in js |
 | team | reference | /teams/5dikjenJj9kJH2 | Reference to the team document |
 | theme | string | "Pandas" |  |
+| chooser | string | "Michael Jordan" | The person who's chosen the theme |
 
 ##### Collection usersMetadata
 

--- a/front/src/services/teams.service.js
+++ b/front/src/services/teams.service.js
@@ -45,19 +45,21 @@ export default class TeamsService {
             .get();
     }
 
-    saveTheme(id, theme, teamId, date) {
+    saveTheme(id, theme, teamId, date, chooser) {
 
         if (id) {
             return this.db.collection('themes')
                 .doc(id)
                 .set({
                     theme,
+                    chooser
                 }, { merge: true });
 
         } else {
             return this.db.collection('themes')
                 .add({
                     theme,
+                    chooser,
                     team: this.db.collection('teams').doc(teamId),
                     date
                 });

--- a/front/src/views/Schedule.vue
+++ b/front/src/views/Schedule.vue
@@ -43,6 +43,15 @@
                                 <div>{{ props.item.day }}</div>
                             </td>
                             <td>
+                                <div v-if="!props.item.chooser">❓</div>
+                                <v-tooltip left z-index="10" v-if="props.item.chooser">
+                                    <template v-slot:activator="{ on }">
+                                        <span v-on="on">{{ getInitials(props.item.chooser) }}</span>
+                                    </template>
+                                    <span>{{ props.item.chooser }}</span>
+                                </v-tooltip>
+                            </td>
+                            <td>
                                 <v-edit-dialog
                                     :return-value.sync="props.item.theme"
                                     large
@@ -96,6 +105,7 @@ export default {
                     sortable: false,
                     value: 'day',
                 },
+                { text: 'Chooser', value: 'chooser' },
                 { text: 'Gif Theme', value: 'theme' },
             ],
             defaultGifs: [
@@ -128,7 +138,7 @@ export default {
         this.teamsService = new TeamsService();
         this.loadWeek();
     },
-    computed: mapState(['user', 'assignedTeamId' ]),
+    computed: mapState(['user', 'assignedTeamId']),
     watch: {
         assignedTeamId() {
             this.loadWeek();
@@ -156,13 +166,19 @@ export default {
                 const dayDate = new Date();
                 dayDate.setDate(startDate.getDate() + index);
 
+                const dayNumber = (startDate.getDate() + index) % this.numberOfDaysInMonth(startDate)
+
                 this.gifs.push({
-                    day: `${d.day} ${startDate.getDate() + index}`,
+                    day: `${d.day} ${ dayNumber !== 0 ? dayNumber : startDate.getDate() + index }`,
                     theme : d.theme,
                     date: dayDate,
-                    isHighlight:  new Date(this.date).getDate() === dayDate.getDate()
+                    isHighlight:  new Date(this.date).getDate() === dayDate.getDate(),
+                    chooser: d.chooser
                 })
             });
+        },
+        numberOfDaysInMonth(date) {
+            return new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate();
         },
         loadWeek() {
 
@@ -181,6 +197,7 @@ export default {
                             this.gifs[day - 1].id = doc.id;
                             this.gifs[day - 1].theme = item.theme;
                             this.gifs[day - 1].date = item.date;
+                            this.gifs[day - 1].chooser = item.chooser;
                         });
                     })
                     .catch(error => {
@@ -191,8 +208,13 @@ export default {
             }
         },
         save(event) {
-            this.teamsService.saveTheme(event.id, event.theme, this.assignedTeamId, event.date);
+            this.teamsService.saveTheme(event.id, event.theme, this.assignedTeamId, event.date, this.user.displayName)
+                .then(() => event.chooser = this.user.displayName);
         },
+        getInitials(displayName) {
+            const initials = displayName.match(/\b\w/g) || [];
+            return ((initials.shift() || '') + '.' + (initials.pop() || '')).toUpperCase();
+        }
     }
 }
 </script>


### PR DESCRIPTION
## Description

I want to know who has chosen the test for a day.

- [x] Display initials of the chooser

- [x] Display a tooltip with complete name

- [x] Fix the day number issue when end of the month (see screenshot)

- [x] Update documentation

## Screenshot

![Capture d’écran 2020-04-11 à 13 43 17](https://user-images.githubusercontent.com/47851994/79043139-b4e3ed00-7bfd-11ea-979c-7074a1513b4e.png)
![Capture d’écran 2020-04-11 à 13 43 32](https://user-images.githubusercontent.com/47851994/79043140-b6151a00-7bfd-11ea-9d1c-adf1921c1639.png)

### Fix number of day increment 🚨

![Capture d’écran 2020-04-11 à 14 02 47](https://user-images.githubusercontent.com/47851994/79043141-b6adb080-7bfd-11ea-9af3-2743fbc1358a.png)
![Capture d’écran 2020-04-11 à 14 03 58](https://user-images.githubusercontent.com/47851994/79043142-b6adb080-7bfd-11ea-95ff-906dfdba6e81.png)

## GIF !

![](https://media1.giphy.com/media/5nkIn9AEfUQ6JtXL43/giphy.gif?cid=5a38a5a20517c44e223f0a100bd330dda1228827f95973dc&rid=giphy.gif)
