### PR TITLE
fix: allow theme choosing only if belonging to a team

### DIFF
--- a/front/src/components/Drawer.vue
+++ b/front/src/components/Drawer.vue
@@ -18,7 +18,7 @@
         <v-divider></v-divider>
         <v-list dense nav>
             <template v-for="item in items">
-                <v-list-item :key="item.title" v-if="!item.needAuth || user && organizationId" link :to="item.href">
+                <v-list-item :key="item.title" v-if="canDisplay(item)" link :to="item.href">
                     <v-list-item-icon>
                         <v-icon>{{ item.icon }}</v-icon>
                     </v-list-item-icon>
@@ -54,16 +54,16 @@ export default {
     data () {
         return {
             items: [
-                { title: 'Dashboard', icon: 'mdi-view-dashboard', href: '/', needAuth: false },
-                { title: 'Gifs', icon: 'mdi-gif', href: '/gifs', needAuth: true },
-                { title: 'Schedule', icon: 'mdi-calendar', href: '/schedule', needAuth: true },
-                { title: 'Teams', icon: 'mdi-account-group', href: '/teams', needAuth: true },
-                { title: 'Faq', icon: 'mdi-help-box', href: '/faq', needAuth: false }
+                { title: 'Dashboard', icon: 'mdi-view-dashboard', href: '/', needAuth: false, needTeam: false },
+                { title: 'Gifs', icon: 'mdi-gif', href: '/gifs', needAuth: true, needTeam: false },
+                { title: 'Schedule', icon: 'mdi-calendar', href: '/schedule', needAuth: true, needTeam: true },
+                { title: 'Teams', icon: 'mdi-account-group', href: '/teams', needAuth: true, needTeam: false },
+                { title: 'Faq', icon: 'mdi-help-box', href: '/faq', needAuth: false, needTeam: false }
             ],
         }
     },
     computed: {
-        ...mapState([ 'organizationId' ]),
+        ...mapState([ 'organizationId', 'assignedTeamId' ]),
         user() {
             return this.$store.getters.user;
         },
@@ -71,6 +71,12 @@ export default {
             return this.user.photoURL || `https://eu.ui-avatars.com/api/?name=${this.user.email}`
         }
     },
+    methods: {
+        canDisplay(item) {
+            return !item.needAuth // Display if no need to be authenticated
+                || this.user && this.organizationId && (!item.needTeam || item.needTeam && this.assignedTeamId) // Display if authenticated, belonging to an organization and belonging to a team if needTeam
+        }
+    }
 }
 </script>
 

--- a/front/src/router/index.js
+++ b/front/src/router/index.js
@@ -18,6 +18,7 @@ const routes = [
         meta: {
             requireAuth: true,
             requireOrganization: true,
+            requireTeam: false,
         },
         component: Home,
     },
@@ -27,6 +28,7 @@ const routes = [
         meta: {
             requireAuth: true,
             requireOrganization: false,
+            requireTeam: false,
         },
         component: Logout,
     },
@@ -36,6 +38,7 @@ const routes = [
         meta: {
             requireAuth: false,
             requireOrganization: false,
+            requireTeam: false,
         },
         component: Login,
     },
@@ -45,6 +48,7 @@ const routes = [
         meta: {
             requireAuth: false,
             requireOrganization: false,
+            requireTeam: false,
         },
         component: Register,
     },
@@ -54,6 +58,7 @@ const routes = [
         meta: {
             requireAuth: false,
             requireOrganization: false,
+            requireTeam: false,
         },
         component: Faq,
     },
@@ -63,6 +68,7 @@ const routes = [
         meta: {
             requireAuth: false,
             requireOrganization: false,
+            requireTeam: false,
         },
         component: About,
     },
@@ -72,6 +78,7 @@ const routes = [
         meta: {
             requireAuth: true,
             requireOrganization: true,
+            requireTeam: false,
         },
         component: () =>
             import(/* webpackChunkName: "about" */ '../views/Teams.vue'),
@@ -82,6 +89,7 @@ const routes = [
         meta: {
             requireAuth: true,
             requireOrganization: true,
+            requireTeam: false,
         },
         component: () =>
             import(/* webpackChunkName: "about" */ '../views/Gifs.vue'),
@@ -92,6 +100,7 @@ const routes = [
         meta: {
             requireAuth: true,
             requireOrganization: true,
+            requireTeam: true,
         },
         component: () =>
             import(/* webpackChunkName: "about" */ '../views/Schedule.vue'),
@@ -102,6 +111,7 @@ const routes = [
         meta: {
             requireAuth: true,
             requireOrganization: false,
+            requireTeam: false,
         },
         component: () =>
             import(/* webpackChunkName: "about" */ '../views/ProfileNotAccepted.vue'),
@@ -120,6 +130,11 @@ router.beforeEach(async (to, from, next) => {
 
     const requireAuth = to.matched.some((record) => record.meta.requireAuth);
     const requireOrganization = to.matched.some((record) => record.meta.requireOrganization);
+    const requireTeam = to.matched.some((record) => record.meta.requireTeam);
+
+    if (requireTeam && !store.state.assignedTeamId) {
+        next('/');
+    }
 
     const shouldRedirect = Boolean(
         to.name === 'home' && lastRouteName && isFirstTransition

--- a/front/src/views/Home.vue
+++ b/front/src/views/Home.vue
@@ -32,7 +32,7 @@
                     </v-card>
                 </v-col>
 
-                <v-col cols="12">
+                <v-col cols="12" v-if="team">
                     <v-card color="blue lighten-1" dark>
                         <v-card-title class="headline">The Gif of the Day</v-card-title>
 
@@ -48,7 +48,7 @@
                     </v-card>
                 </v-col>
             </v-row>
-            <div class="gif-frame-container" v-if="gif">
+            <div class="gif-frame-container" v-if="gif && team && theme">
                 <img :src="gif.images.downsized.url" :alt="gif.title" />
             </div>
         </v-container>


### PR DESCRIPTION
## Description

Allow a user to choose a theme only if belonging to a team:

- [x] Router guard

- [x] Drawer button

- [x] Home tile

## Screenshot

![Capture d’écran 2020-04-11 à 14 32 31](https://user-images.githubusercontent.com/47851994/79043747-78b28b80-7c01-11ea-9f6b-516ef0e8ac80.png)
![Capture d’écran 2020-04-11 à 14 32 44](https://user-images.githubusercontent.com/47851994/79043748-79e3b880-7c01-11ea-8ee3-3f000099dd06.png)


## GIF !


![](https://media1.giphy.com/media/LxnaFk7seJCnu/giphy.gif?cid=5a38a5a29fa8343b05fea12f0f37f3dbb3b38bee4d931a6b&rid=giphy.gif)

