### PR TITLE
fix: redirect to '/new/choose' issue template instead of '/new'

### DIFF
--- a/front/src/components/Footer.vue
+++ b/front/src/components/Footer.vue
@@ -23,7 +23,7 @@
           icon
           dark
           v-on="on"
-          href="https://github.com/ytvnr/gif-of-the-day/issues/new"
+          href="https://github.com/ytvnr/gif-of-the-day/issues/new/choose"
           target="_blank"
         >🐛</v-btn>
       </template>


### PR DESCRIPTION
## Description

Redirect to /issues/new/choose to let the reporter pick up a template

## GIF !

![](https://media1.giphy.com/media/LSX49vHf7JHGyGjrC0/giphy.gif?cid=5a38a5a2ba756ae6439768089800d08dda0a98a87ef5a59c&rid=giphy.gif)
