### PR TITLE
fix: display home page random gif into a card

### DIFF
--- a/front/src/views/Home.vue
+++ b/front/src/views/Home.vue
@@ -47,10 +47,12 @@
                         </v-card-actions>
                     </v-card>
                 </v-col>
+                <v-col cols="12" v-if="gif && team && theme">
+                    <v-card class="gif-frame-container" color="transparent" dark>
+                        <img :src="gif.images.downsized.url" :alt="gif.title" />
+                    </v-card>
+                </v-col>
             </v-row>
-            <div class="gif-frame-container" v-if="gif && team && theme">
-                <img :src="gif.images.downsized.url" :alt="gif.title" />
-            </div>
         </v-container>
     </div>
 </template>
@@ -139,12 +141,8 @@ export default {
 }
 
 .gif-frame-container {
-    display: flex;
+    display: flex !important;
     justify-content: center;
-}
-
-.gif-frame {
-    border: none;
 }
 
 a {


### PR DESCRIPTION
## Description

Display home page random gif in a card to avoid overflow if gif is too big

## Screenshot

![Capture d’écran 2020-04-11 à 14 55 17](https://user-images.githubusercontent.com/47851994/79044278-7dc50a00-7c04-11ea-9419-d17b3877d880.png)


## GIF !

![](https://media1.giphy.com/media/6nps2nX9fGV9K/giphy.gif?cid=5a38a5a25e27d1f89a3b8da8dbc97553818b8fcc56ed2aa7&rid=giphy.gif)

