### PR TITLE
fix: change home tiles order and add link to FAQ

### DIFF
--- a/front/src/views/Home.vue
+++ b/front/src/views/Home.vue
@@ -54,9 +54,7 @@
 
                 <v-col cols="12">
                     <v-card color="blue-grey darken-1" dark>
-                        <v-card-title class="headline">Your team</v-card-title>
-
-                        <v-card-subtitle>Some questions ?</v-card-subtitle>
+                        <v-card-title class="headline">Some questions ?</v-card-title>
 
                         <v-card-actions>
                             <router-link :to="{ name: 'faq' }">

--- a/front/src/views/Home.vue
+++ b/front/src/views/Home.vue
@@ -6,29 +6,8 @@
                     <v-card color="green darken-3" dark>
                         <v-card-title class="headline">
                             Welcome,
-                            {{ user.displayName || user.email }}
+                            {{ user.displayName || user.email }}!
                         </v-card-title>
-
-                        <v-card-subtitle v-if="assignedTeamId">Random phrase of the day !</v-card-subtitle>
-                    </v-card>
-                </v-col>
-
-                <v-col cols="12">
-                    <v-card color="amber darken-3" dark>
-                        <v-card-title class="headline">Your team</v-card-title>
-
-                        <v-card-subtitle v-if="team">Your team is {{ team.name }}</v-card-subtitle>
-
-                        <v-card-subtitle v-if="!assignedTeamId">
-                            Your are not assigned to a team. Please join
-                            one.
-                        </v-card-subtitle>
-
-                        <v-card-actions v-if="!assignedTeamId">
-                            <router-link :to="{ name: 'teams' }">
-                                <v-btn text>Join a team!</v-btn>
-                            </router-link>
-                        </v-card-actions>
                     </v-card>
                 </v-col>
 
@@ -47,9 +26,43 @@
                         </v-card-actions>
                     </v-card>
                 </v-col>
+
                 <v-col cols="12" v-if="gif && team && theme">
-                    <v-card class="gif-frame-container" color="transparent" dark>
-                        <img :src="gif.images.downsized.url" :alt="gif.title" />
+                    <v-card class="gif-frame-container" color="indigo" dark>
+                        <img class="gif" :src="gif.images.downsized.url" :alt="gif.title" />
+                    </v-card>
+                </v-col>
+
+                <v-col cols="12">
+                    <v-card color="deep-purple darken-4" dark>
+                        <v-card-title class="headline">Your team</v-card-title>
+
+                        <v-card-subtitle v-if="team">Your team is <strong>{{ team.name }}</strong></v-card-subtitle>
+
+                        <v-card-subtitle v-if="!assignedTeamId">
+                            Your are not assigned to a team. Please join
+                            one.
+                        </v-card-subtitle>
+
+                        <v-card-actions v-if="!assignedTeamId">
+                            <router-link :to="{ name: 'teams' }">
+                                <v-btn text>Join a team!</v-btn>
+                            </router-link>
+                        </v-card-actions>
+                    </v-card>
+                </v-col>
+
+                <v-col cols="12">
+                    <v-card color="blue-grey darken-1" dark>
+                        <v-card-title class="headline">Your team</v-card-title>
+
+                        <v-card-subtitle>Some questions ?</v-card-subtitle>
+
+                        <v-card-actions>
+                            <router-link :to="{ name: 'faq' }">
+                                <v-btn text>Go to our FAQ!</v-btn>
+                            </router-link>
+                        </v-card-actions>
                     </v-card>
                 </v-col>
             </v-row>
@@ -143,6 +156,11 @@ export default {
 .gif-frame-container {
     display: flex !important;
     justify-content: center;
+}
+
+.gif {
+    max-width: 100%;
+    padding: 12px 0;
 }
 
 a {


### PR DESCRIPTION
![GitHub issue/pull request detail](https://img.shields.io/github/issues/detail/title/ytvnr/gif-of-the-day/112?color=red&style=for-the-badge&logo=vue.js)
![GitHub issue/pull request detail](https://img.shields.io/github/issues/detail/title/ytvnr/gif-of-the-day/102?color=red&style=for-the-badge&logo=vue.js)

Fixes #102 

## Description

Change order of the tiles and add a link to FAQ page.

## Screenshot

![Capture d’écran 2020-04-14 à 07 10 45](https://user-images.githubusercontent.com/47851994/79188565-a5dc8500-7e1f-11ea-9ff4-ad5fc96b302e.png)

## GIF !

![](https://media1.giphy.com/media/xT0xeuOy2Fcl9vDGiA/giphy.gif?cid=5a38a5a2d5d7d6bf857ec73027ed8f11cef981b7f22f7087&rid=giphy.gif)
