### PR TITLE
feat: return from ouahid's test session

### DIFF
--- a/front/src/components/Footer.vue
+++ b/front/src/components/Footer.vue
@@ -1,6 +1,6 @@
 <template>
   <v-footer :inset="false" app>
-    <router-link to="about">&copy; 2019 - {{ new Date().getFullYear() }}</router-link>
+    <router-link class="link" to="about">&copy; 2019 - {{ new Date().getFullYear() }}</router-link>
 
     <v-spacer></v-spacer>
 
@@ -45,5 +45,13 @@ export default {
 }
 </script>
 
-<style>
+<style scoped lang="scss">
+.link {
+  color: white;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
 </style>

--- a/front/src/components/NavBar.vue
+++ b/front/src/components/NavBar.vue
@@ -87,7 +87,7 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style scoped lang="scss">
 .title {
   color: #42b983 !important;
   margin-bottom: 0px !important;

--- a/front/src/components/TeamCard.vue
+++ b/front/src/components/TeamCard.vue
@@ -65,7 +65,7 @@ export default {
 }
 </script>
 
-<style>
+<style scoped>
 .selected {
     background-color: rgba(30, 30, 30, 0.12) !important;
     box-shadow: 0 0 30px 5px lime;

--- a/front/src/views/Faq.vue
+++ b/front/src/views/Faq.vue
@@ -33,7 +33,7 @@
 </template>
 
 
-<style lang="scss" scoped>
+<style scoped lang="scss">
 li {
     padding: 10px 0px;
 }

--- a/front/src/views/Gifs.vue
+++ b/front/src/views/Gifs.vue
@@ -119,7 +119,7 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style scoped lang="scss">
 .gifs {
     &__container {
         height: calc(100vh - 200px);

--- a/front/src/views/Home.vue
+++ b/front/src/views/Home.vue
@@ -140,7 +140,7 @@ export default {
 };
 </script>
 
-<style>
+<style scoped>
 .home {
     display: flex;
     flex-direction: column;
@@ -158,7 +158,7 @@ export default {
 
 .gif {
     max-width: 100%;
-    padding: 12px 0;
+    padding: 12px;
 }
 
 a {

--- a/front/src/views/Login.vue
+++ b/front/src/views/Login.vue
@@ -10,7 +10,7 @@
                         Login with
                         <v-icon color="error">mdi-twitter</v-icon>
                     </v-btn>
-                    <v-btn disabled color="white">
+                    <v-btn v-if="0" disabled color="white">
                         <img width="85" src="img/github.png" alt="Login with Gihub" />
                     </v-btn>
                 </v-card-actions>

--- a/front/src/views/Logout.vue
+++ b/front/src/views/Logout.vue
@@ -17,5 +17,5 @@ export default {
 }
 </script>
 
-<style>
+<style scoped>
 </style>

--- a/front/src/views/ProfileNotAccepted.vue
+++ b/front/src/views/ProfileNotAccepted.vue
@@ -13,7 +13,7 @@
 export default {};
 </script>
 
-<style lang="scss">
+<style scoped lang="scss">
 h2 {
     text-align: center;
 }

--- a/front/src/views/Register.vue
+++ b/front/src/views/Register.vue
@@ -180,7 +180,7 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style scoped lang="scss">
 .full-screen {
     width: calc(100% + 24px);
     height: calc(100vh - 96px);

--- a/front/src/views/Schedule.vue
+++ b/front/src/views/Schedule.vue
@@ -69,7 +69,7 @@
                                             single-line
                                             counter
                                             autofocus
-                                            maxlength="30"
+                                            maxlength="20"
                                         ></v-text-field>
                                     </template>
                                 </v-edit-dialog>
@@ -219,7 +219,7 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style scoped lang="scss">
 .schedule {
     width: calc(100% + 24px);
     height: calc(100vh - 96px);

--- a/front/src/views/Teams.vue
+++ b/front/src/views/Teams.vue
@@ -82,7 +82,7 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style scoped lang="scss">
 .container {
     padding-top: 20px;
 }


### PR DESCRIPTION
![GitHub issue/pull request detail](https://img.shields.io/github/issues/detail/title/ytvnr/gif-of-the-day/112?color=red&style=for-the-badge&logo=vue.js)



## Description

- [x] Add scoped on style attribute. (Not done on App, Drawer and Login because it breaks style)

- [x] Limit size to 20 for theme in Schedule page

- [x] Padding for Home gif card

- [x] Remove Github login

- [x] Bonus: change 2019-2020 style

## Screenshot

<img width="917" alt="Capture d’écran 2020-04-17 à 08 31 07" src="https://user-images.githubusercontent.com/47851994/79539059-df162e80-8085-11ea-8284-b67ca7f98113.png">
<img width="917" alt="Capture d’écran 2020-04-17 à 08 31 14" src="https://user-images.githubusercontent.com/47851994/79539062-dfaec500-8085-11ea-94b4-220efbca0e0c.png">

## GIF !

![](https://media2.giphy.com/media/PgiG2vnNzZ4Qm394h8/giphy.gif?cid=5a38a5a22e1e0b08af79d0448fc58544189de60cf7ffc006&rid=giphy.gif)


