### PR TITLE
fix: be enable to select date in the future

### DIFF
--- a/front/src/views/Schedule.vue
+++ b/front/src/views/Schedule.vue
@@ -22,7 +22,7 @@
                             <v-btn text color="primary" @click="setToday()">Today</v-btn>
                             <v-spacer></v-spacer>
                             <v-btn text color="primary" @click="modal = false">Cancel</v-btn>
-                            <v-btn text color="primary" @click="$refs.dialog.save(date)">OK</v-btn>
+                            <v-btn text color="primary" @click="selectDate(date)">OK</v-btn>
                         </v-date-picker>
                     </v-dialog>
                 </v-card-actions>
@@ -154,6 +154,10 @@ export default {
             this.date = new Date().toISOString().substr(0, 10);
             this.$refs.dialog.save(this.date);
         },
+        selectDate(date) {
+            this.date = new Date(date).toISOString().substr(0, 10);
+            this.$refs.dialog.save(this.date);
+        },
         getMonday(d) {
             d = new Date(d);
             const day = d.getDay();
@@ -186,7 +190,7 @@ export default {
 
             const start = this.getMonday(this.date);
             const end = new Date();
-            end.setDate(start.getDate() + 7);
+            end.setDate(start.getDate() + 6);
 
             this.loadDefaultWeek(start);
 			


### PR DESCRIPTION
![GitHub issue/pull request detail](https://img.shields.io/github/issues/detail/title/ytvnr/gif-of-the-day/134?color=red&style=for-the-badge&logo=vue.js)

Fixes #134 

## Description
We were not able to select a theme in the future
It was due to week start from monday to end on next monday (and this last was taken into account)

## Screenshot
![image](https://user-images.githubusercontent.com/47851994/80062618-753dcf00-8534-11ea-881d-8eef752eaa41.png)
![image](https://user-images.githubusercontent.com/47851994/80062637-7c64dd00-8534-11ea-8b20-4af6f6f708d8.png)


## GIF !

![](https://media0.giphy.com/media/5q3NyUvgt1w9unrLJ9/giphy.gif?cid=5a38a5a2fcce5fea5b464ef71b7264249e2027dcb3ccce00&rid=giphy.gif)
