### PR TITLE
feat: copy gif url to clipboard

### DIFF
--- a/front/src/components/FullScreenGif.vue
+++ b/front/src/components/FullScreenGif.vue
@@ -67,7 +67,7 @@ export default {
     &__copier {
         position: absolute;
         bottom: 10px;
-        right: 20px;
+        right: 25px;
     }
 }
 </style>

--- a/front/src/components/FullScreenGif.vue
+++ b/front/src/components/FullScreenGif.vue
@@ -9,16 +9,16 @@
             :hidden="!isImageLoad"
         />
         <v-skeleton-loader v-if="!isImageLoad" type="image" class="gif__skeleton"></v-skeleton-loader>
-        <god-giphy-powered class="gif__giphy" />
+        <god-url-copier class="gif__copier" :url="gif.images.original.url" />
     </div>
 </template>
 
 <script>
-import GiphyPowered from '@/components/GiphyPowered.vue';
+import UrlCopier from '@/components/UrlCopier.vue';
 
 export default {
     components: {
-        'god-giphy-powered': GiphyPowered
+        'god-url-copier': UrlCopier
     },
     data() {
         return {
@@ -59,6 +59,12 @@ export default {
     }
 
     &__giphy {
+        position: absolute;
+        bottom: 10px;
+        right: 20px;
+    }
+
+    &__copier {
         position: absolute;
         bottom: 10px;
         right: 20px;

--- a/front/src/components/RefreshButton.vue
+++ b/front/src/components/RefreshButton.vue
@@ -1,0 +1,69 @@
+<template>
+        <v-btn
+                class="refresher"
+                text
+                @click="$emit('click')"
+        >
+            <v-icon :class="{'loading': isLoading}" left>mdi-refresh</v-icon>
+            Refresh
+        </v-btn>
+</template>
+
+<script>
+export default {
+    props: ['isLoading'],
+    watch: {
+        isLoading() {
+            console.log('isLoading', this.isLoading)
+        }
+    }
+}
+</script>
+
+<style scoped lang="scss">
+.refresher {
+    width: 120px;
+    background-color: grey;
+
+    button {
+        margin: 0;
+    }
+}
+
+.loading {
+    animation: loader 1s infinite;
+    display: flex;
+}
+@-moz-keyframes loader {
+    from {
+        transform: rotate(0);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}
+@-webkit-keyframes loader {
+    from {
+        transform: rotate(0);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}
+@-o-keyframes loader {
+    from {
+        transform: rotate(0);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}
+@keyframes loader {
+    from {
+        transform: rotate(0);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}
+</style>

--- a/front/src/components/UrlCopier.vue
+++ b/front/src/components/UrlCopier.vue
@@ -2,7 +2,6 @@
     <div class="copier">
         <input id="urlInput" type="hidden" :value="url"/>
         <v-btn
-                class="ma-2"
                 :class="btnState.class"
                 :block="true"
                 text

--- a/front/src/components/UrlCopier.vue
+++ b/front/src/components/UrlCopier.vue
@@ -1,0 +1,66 @@
+<template>
+    <div class="copier">
+        <input id="urlInput" type="hidden" :value="url"/>
+        <v-btn
+                class="ma-2"
+                :class="btnState.class"
+                :block="true"
+                text
+                @click="copyLink()"
+        >{{ btnState.text }}</v-btn>
+    </div>
+</template>
+
+<script>
+
+const copyState = {
+    class: "copier__ready",
+    text: "Copy Link"
+};
+
+const copiedState = {
+    class: "copier__copied",
+    text: "Copied!"
+};
+
+export default {
+    props: ['url'],
+    data() {
+        return {
+            btnState: copyState
+        }
+    },
+    methods: {
+        copyLink() {
+
+            let testingCodeToCopy = document.querySelector('#urlInput');
+            testingCodeToCopy.setAttribute('type', 'text');
+            testingCodeToCopy.select();
+            document.execCommand('copy');
+
+            testingCodeToCopy.setAttribute('type', 'hidden');
+            window.getSelection().removeAllRanges();
+
+            //Manage this with css classes
+            this.btnState = copiedState;
+
+            setTimeout(() => this.btnState = copyState, 3000);
+        }
+    }
+}
+</script>
+
+<style scoped lang="scss">
+.copier {
+    width: 120px;
+
+    &__ready {
+        background-color: green;
+        transition: background-color 1s ease-in;
+    }
+
+    &__copied {
+        background-color: orange;
+    }
+}
+</style>

--- a/front/src/views/Home.vue
+++ b/front/src/views/Home.vue
@@ -31,6 +31,12 @@
                     <v-card class="gif-frame-container" color="indigo" dark>
                         <img class="gif" :src="gif.images.downsized.url" :alt="gif.title" />
                         <god-giphy-powered />
+                        <god-refresher
+                            class="gif__refresh"
+                            v-on:click.native="getRandomGif()"
+                            :isLoading="isGifLoading"
+                        />
+                        <god-url-copier class="gif__copier" :url="gif.images.original.url" />
                     </v-card>
                 </v-col>
 
@@ -78,11 +84,15 @@ import { mapState } from 'vuex';
 import GiphyService from '@/services/giphy.service';
 import TeamsService from '@/services/teams.service';
 import GiphyPowered from '@/components/GiphyPowered.vue';
+import UrlCopier from '@/components/UrlCopier.vue';
+import RefreshButton from '@/components/RefreshButton.vue';
 
 export default {
     name: 'home',
     components: {
-        'god-giphy-powered': GiphyPowered
+        'god-giphy-powered': GiphyPowered,
+        'god-url-copier': UrlCopier,
+        'god-refresher': RefreshButton,
     },
     data() {
         return {
@@ -91,6 +101,7 @@ export default {
             gif: null,
             giphyService: new GiphyService(),
             teamsService: null,
+            isGifLoading: true
         };
     },
     created() {
@@ -119,7 +130,7 @@ export default {
                 });
         },
         getThemeByTeamId(teamId) {
-			
+
             let start = new Date()
             start.setUTCHours(0,0,0,0);
             let end = new Date()
@@ -136,12 +147,17 @@ export default {
                     snapshots.forEach((doc) => {
                         const item = doc.data();
                         this.theme = item.theme;
-                        this.giphyService.randomByTag(this.theme)
-                            .then(resp => JSON.parse(JSON.stringify(resp.data)))
-                            .then(result => {
-                                this.gif = result.data;
-                            });
+                        this.getRandomGif();
                     });
+                });
+        },
+        getRandomGif() {
+            this.isGifLoading = true;
+            this.giphyService.randomByTag(this.theme)
+                .then(resp => JSON.parse(JSON.stringify(resp.data)))
+                .then(result => {
+                    this.gif = result.data;
+                    this.isGifLoading = false;
                 });
         }
     }
@@ -168,6 +184,22 @@ export default {
 
     .gif {
         max-width: 100%;
+
+        &__copier {
+            position: absolute;
+            bottom: 20px;
+            right: 25px;
+
+            button {
+               margin: 0;
+            }
+        }
+
+        &__refresh {
+            position: absolute;
+            bottom: 20px;
+            right: 150px;
+        }
     }
 
     a {


### PR DESCRIPTION
![GitHub issue/pull request detail](https://img.shields.io/github/issues/detail/title/ytvnr/gif-of-the-day/142?color=red&style=for-the-badge&logo=vue.js)

Fixes #142 

## Description

Be able to get gif url on full size visualization.
Bonus: Refresh button on home page

## Screenshot

<img width="623" alt="Capture d’écran 2020-04-28 à 13 27 08" src="https://user-images.githubusercontent.com/47851994/80482391-6f8d2280-8954-11ea-9be0-d38f86b7efcb.png">
<img width="623" alt="Capture d’écran 2020-04-28 à 13 27 13" src="https://user-images.githubusercontent.com/47851994/80482394-70be4f80-8954-11ea-8897-2253eaa97d4c.png">
<img width="677" alt="Capture d’écran 2020-04-29 à 07 31 48" src="https://user-images.githubusercontent.com/47851994/80563611-ce51ab00-89eb-11ea-8f6c-53c50a4f25fd.png">


## GIF !

![](https://media0.giphy.com/media/8OPmI31cPU7YLaUPQH/giphy.gif?cid=5a38a5a206ca12f21dd1469c3464f4c976f3a78757d56256&rid=giphy.gif)
