### PR TITLE
feat: refine UI for refresh and copy buttons on home page 💄

### DIFF
--- a/front/src/components/RefreshButton.vue
+++ b/front/src/components/RefreshButton.vue
@@ -3,31 +3,27 @@
                 class="refresher"
                 text
                 @click="$emit('click')"
+                small
         >
-            <v-icon :class="{'loading': isLoading}" left>mdi-refresh</v-icon>
-            Refresh
+            <v-icon :class="{'loading': isLoading}">mdi-refresh</v-icon>
         </v-btn>
 </template>
 
 <script>
 export default {
     props: ['isLoading'],
-    watch: {
-        isLoading() {
-            console.log('isLoading', this.isLoading)
-        }
-    }
 }
 </script>
 
 <style scoped lang="scss">
 .refresher {
-    width: 120px;
     background-color: grey;
+    padding: 0 10px !important;
+    min-width: 0 !important;
+}
 
-    button {
-        margin: 0;
-    }
+.v-icon {
+    font-size: 20px;
 }
 
 .loading {

--- a/front/src/components/UrlCopier.vue
+++ b/front/src/components/UrlCopier.vue
@@ -1,12 +1,23 @@
 <template>
-    <div class="copier">
+    <div class="copier" :class="{ small }">
         <input id="urlInput" type="hidden" :value="url"/>
         <v-btn
+                v-if="!small"
                 :class="btnState.class"
                 :block="true"
                 text
                 @click="copyLink()"
         >{{ btnState.text }}</v-btn>
+        <v-btn
+                v-if="small"
+                class="copier__btn__small"
+                :class="btnState.class"
+                text
+                small
+                @click="copyLink()"
+        >
+            <v-icon>{{ btnState.icon }}</v-icon>
+        </v-btn>
     </div>
 </template>
 
@@ -14,16 +25,24 @@
 
 const copyState = {
     class: "copier__ready",
-    text: "Copy Link"
+    text: "Copy Link",
+    icon: "mdi-content-copy"
 };
 
 const copiedState = {
     class: "copier__copied",
-    text: "Copied!"
+    text: "Copied!",
+    icon: "mdi-check"
 };
 
 export default {
-    props: ['url'],
+    props: {
+        url: String,
+        small: {
+            type: Boolean,
+            default: false
+        }
+    },
     data() {
         return {
             btnState: copyState
@@ -53,6 +72,10 @@ export default {
 .copier {
     width: 120px;
 
+    &.small {
+        width: 50px;
+    }
+
     &__ready {
         background-color: green;
         transition: background-color 1s ease-in;
@@ -61,5 +84,14 @@ export default {
     &__copied {
         background-color: orange;
     }
+
+    &__btn__small {
+        padding: 0 10px !important;
+        min-width: 0 !important;
+    }
+}
+
+.v-icon {
+    font-size: 20px;
 }
 </style>

--- a/front/src/components/UrlCopier.vue
+++ b/front/src/components/UrlCopier.vue
@@ -1,15 +1,15 @@
 <template>
-    <div class="copier" :class="{ small }">
+    <div class="copier" :class="{ small: isSmall }">
         <input id="urlInput" type="hidden" :value="url"/>
         <v-btn
-                v-if="!small"
+                v-if="!isSmall"
                 :class="btnState.class"
                 :block="true"
                 text
                 @click="copyLink()"
         >{{ btnState.text }}</v-btn>
         <v-btn
-                v-if="small"
+                v-if="isSmall"
                 class="copier__btn__small"
                 :class="btnState.class"
                 text
@@ -38,7 +38,7 @@ const copiedState = {
 export default {
     props: {
         url: String,
-        small: {
+        isSmall: {
             type: Boolean,
             default: false
         }

--- a/front/src/views/Home.vue
+++ b/front/src/views/Home.vue
@@ -38,7 +38,7 @@
                         />
                         <god-url-copier
                             class="gif__copier"
-                            :small="true"
+                            :isSmall="true"
                             :url="gif.images.original.url" />
                     </v-card>
                 </v-col>

--- a/front/src/views/Home.vue
+++ b/front/src/views/Home.vue
@@ -36,7 +36,10 @@
                             v-on:click.native="getRandomGif()"
                             :isLoading="isGifLoading"
                         />
-                        <god-url-copier class="gif__copier" :url="gif.images.original.url" />
+                        <god-url-copier
+                            class="gif__copier"
+                            :small="true"
+                            :url="gif.images.original.url" />
                     </v-card>
                 </v-col>
 
@@ -187,8 +190,8 @@ export default {
 
         &__copier {
             position: absolute;
-            bottom: 20px;
-            right: 25px;
+            top: 20px;
+            right: 15px;
 
             button {
                margin: 0;
@@ -197,8 +200,8 @@ export default {
 
         &__refresh {
             position: absolute;
-            bottom: 20px;
-            right: 150px;
+            top: 20px;
+            right: 70px;
         }
     }
 


### PR DESCRIPTION
![GitHub issue/pull request detail](https://img.shields.io/github/issues/detail/title/ytvnr/gif-of-the-day/144?color=red&style=for-the-badge&logo=vue.js)

Fixes #144 

## Description
Reduce size of buttons in home page that appears very big in extension mode

## Screenshot
![image](https://user-images.githubusercontent.com/47851994/81141605-8394dd80-8f6d-11ea-891e-c14e8fae9da6.png)


## GIF !

![](https://media1.giphy.com/media/pk3FGxMUnfHZsnoCAW/giphy.gif?cid=5a38a5a2f743e0581efc2da5280ba96947e231c89d1246ce&rid=giphy.gif)

